### PR TITLE
Add Facebook like button

### DIFF
--- a/assets/javascripts/coursemology.org/facebook.js
+++ b/assets/javascripts/coursemology.org/facebook.js
@@ -1,0 +1,64 @@
+// The official Facebook SDK does not play well with Turbolinks. To get it to
+// work, some workarounds are needed, which are explained below.
+//
+// There needs to be some coordination between the HTML and the JavaScript. The
+// HTML looks like this:
+//
+//   body
+//     #fb-root[data-turbolinks-permanent]
+//     / The code below does not come from FB
+//     javascript:
+//       typeof FB !== "undefined" && FB !== null ? FB.XFBML.parse() : void 0;
+//
+//   ...
+//
+//   div.fb-like[data-href="https://www.facebook.com/coursemology"
+//               data-width="20"
+//               data-layout="button_count"
+//               data-action="like"
+//               data-size="small"
+//               data-show-faces="false"
+//               data-share="false"]
+//
+// The SDK requires that the first element in the body is div#fb-root, which is
+// the mechanism that the SDK uses to communicate with the Facebook servers.
+// Because we are using Turbolinks, upon each visit, the contents of #fb-root
+// would be lost. We need to give it the attribute data-turbolinks-permanent,
+// so that the contents of #fb-root are persisted across Turbolinks visits.
+//
+// Immediately after #fb-root is parsed, we need to execute
+//
+//   typeof FB !== "undefined" && FB !== null ? FB.XFBML.parse() : void 0;
+//
+// The like button itself is represented by div.fb-like. We cannot use the same
+// data-turbolinks-permanent trick to persist it across Turbolinks visits
+// because within it there is an iframe that fails to be persisted to the new
+// page properly. To work around that, we can only load an empty div.fb-like
+// upon each Turbolinks visit and then use the above code to re-activate the
+// SDK, which will in turn transform the empty div to the Facebook like button.
+//
+// The code,
+//
+//   typeof FB !== "undefined" && FB !== null ? FB.XFBML.parse() : void 0;
+//
+// , is a bit of a hack and relies on the fact that enough of the Facebook SDK
+// is retained across Turbolinks visits such that the above code is able to
+// bring it back to life.
+var loadFacebookSDK;
+
+$(function() {
+  loadFacebookSDK();
+});
+
+loadFacebookSDK = function() {
+  // The code in this function came from FB's code generator verbatim
+  /* jshint ignore:start */
+  (function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+        js = d.createElement(s); js.id = id;
+          js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.7";
+            fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));
+  /* jshint ignore:end */
+};

--- a/assets/stylesheets/coursemology.org/facebook_like_button.scss
+++ b/assets/stylesheets/coursemology.org/facebook_like_button.scss
@@ -1,0 +1,4 @@
+.navbar-header .fb-like {
+  float: left;
+  padding: 15px;
+}

--- a/views/layouts/coursemology.org.html.slim
+++ b/views/layouts/coursemology.org.html.slim
@@ -12,6 +12,10 @@ html
     = header_tags
 
   body
+    #fb-root[data-turbolinks-permanent]
+    / The code below does not come from FB
+    javascript:
+      typeof FB !== "undefined" && FB !== null ? FB.XFBML.parse() : void 0;
     nav.navbar.navbar-inverse.navbar-fixed-top role="navigation"
       div.container-fluid
         div.navbar-header
@@ -30,6 +34,13 @@ html
               span.icon-bar
           a.navbar-brand href=root_path
             = t('layout.coursemology')
+          div.fb-like[data-href="https://www.facebook.com/coursemology"
+                      data-width="20"
+                      data-layout="button_count"
+                      data-action="like"
+                      data-size="small"
+                      data-show-faces="false"
+                      data-share="false"]
         div.collapse.navbar-collapse#site-navigation-navbar
           ul.nav.navbar-nav.pull-right
             li


### PR DESCRIPTION
Adding a simple Facebook like button turned out to be more than meets
the eye.

Turns out that the official Facebook like button is incompatible with
Turbolinks and also Coursemology's architecture for tooltips.

Besides adding the Facebook like button, this commit also includes the
necessary workarounds.

To support the Facebook like button, Coursemology's tooltip behavior also has to change. See https://github.com/Coursemology/coursemology2/pull/1542.

![fb-like-big](https://cloud.githubusercontent.com/assets/8869365/18983113/642fe068-871d-11e6-9b31-0f096ead2379.png)
![fb-like-small-portrait](https://cloud.githubusercontent.com/assets/8869365/18983115/677da476-871d-11e6-84ec-d54d4f1bf676.png)
![fb-like-small-landscape](https://cloud.githubusercontent.com/assets/8869365/18983119/6a54b07c-871d-11e6-8595-d3dd8af69e26.png)
