### PR TITLE
Fix collapsed navbar on mobile views

### DIFF
--- a/assets/stylesheets/coursemology.org/layout.scss
+++ b/assets/stylesheets/coursemology.org/layout.scss
@@ -7,45 +7,6 @@
   box-shadow: 0 $v-shadow $blur $spread $gray-light;
 }
 
-.navbar-inverse {
-  @include box-shadow(0, 8px, -3px);
-  border-bottom: 1px solid $gray-lighter;
-  border-top: 4px solid $cyan;
-
-  .navbar-brand {
-    border-right: 1px solid $gray-lighter;
-    color: $gray-darker;
-    font-family: 'Varela Round', sans-serif;
-    font-weight: 400;
-
-    &:hover {
-      color: $cyan;
-    }
-  }
-
-  .navbar-nav > li > a {
-    font-family: 'Varela Round', sans-serif;
-
-    &:hover {
-      color: $cyan;
-    }
-  }
-
-  .navbar-toggle {
-    border-color: transparent;
-
-    &:hover,
-    &:focus,
-    &:active {
-      background-color: transparent;
-    }
-
-    .icon-bar {
-      background-color: $cyan;
-    }
-  }
-}
-
 footer {
   border-top: 1px solid $gray-lighter;
   color: $gray-light;

--- a/assets/stylesheets/coursemology.org/navbar.scss
+++ b/assets/stylesheets/coursemology.org/navbar.scss
@@ -1,25 +1,41 @@
+// scss-lint:disable SelectorDepth
+@mixin navbar-header-text {
+  font-family: 'Varela Round', sans-serif;
+
+  &:hover {
+    color: $cyan;
+  }
+}
+
 .navbar-inverse {
   @include box-shadow(0, 8px, -3px);
   border-bottom: 1px solid $gray-lighter;
   border-top: 4px solid $cyan;
 
+  .nav {
+    max-width: 100%;
+  }
+
   .navbar-brand {
+    @include navbar-header-text;
     border-right: 1px solid $gray-lighter;
     color: $gray-darker;
-    font-family: 'Varela Round', sans-serif;
     font-weight: 400;
+  }
 
-    &:hover {
-      color: $cyan;
+  .navbar-collapse {
+    max-width: 100%;
+
+    a {
+      @media (max-width: $screen-xs-max) {
+        text-align: right;
+        white-space: normal;
+      }
     }
   }
 
   .navbar-nav > li > a {
-    font-family: 'Varela Round', sans-serif;
-
-    &:hover {
-      color: $cyan;
-    }
+    @include navbar-header-text;
   }
 
   .navbar-toggle {
@@ -31,8 +47,10 @@
       background-color: transparent;
     }
 
-    .icon-bar {
+    > .icon-bar {
       background-color: $cyan;
     }
   }
 }
+
+

--- a/assets/stylesheets/coursemology.org/navbar.scss
+++ b/assets/stylesheets/coursemology.org/navbar.scss
@@ -1,0 +1,38 @@
+.navbar-inverse {
+  @include box-shadow(0, 8px, -3px);
+  border-bottom: 1px solid $gray-lighter;
+  border-top: 4px solid $cyan;
+
+  .navbar-brand {
+    border-right: 1px solid $gray-lighter;
+    color: $gray-darker;
+    font-family: 'Varela Round', sans-serif;
+    font-weight: 400;
+
+    &:hover {
+      color: $cyan;
+    }
+  }
+
+  .navbar-nav > li > a {
+    font-family: 'Varela Round', sans-serif;
+
+    &:hover {
+      color: $cyan;
+    }
+  }
+
+  .navbar-toggle {
+    border-color: transparent;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: transparent;
+    }
+
+    .icon-bar {
+      background-color: $cyan;
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes some of the text-overflow encountered when opening the collapsed menus in the navbar. Now course titles are wrapped within the menu. 
### Before

<img src="https://cloud.githubusercontent.com/assets/4353853/19145562/15883e64-8be2-11e6-827a-5f20aa6a760a.gif" width="250">
### After

<img src="https://cloud.githubusercontent.com/assets/4353853/19145568/18e65ba4-8be2-11e6-9f0b-33aa7c0e2108.gif" width="250">
