### PR TITLE
Use default font for about us page

### DIFF
--- a/assets/stylesheets/coursemology.org/pages/about.scss
+++ b/assets/stylesheets/coursemology.org/pages/about.scss
@@ -29,7 +29,6 @@
     text-align: center;
 
     h2 {
-      font-family: "lato", "sans-serif";
       font-size: 30px;
       font-weight: bold;
       margin: 15px 0;
@@ -43,7 +42,6 @@
     }
 
     p {
-      font-family: "lato", "sans-serif";
       font-size: 16px;
       letter-spacing: 0.4px;
       line-height: 1.8;


### PR DESCRIPTION
Now it looks likes: 
<img width="1200" alt="screen shot 2017-01-12 at 7 17 57 pm" src="https://cloud.githubusercontent.com/assets/4983239/21887712/078888de-d8fc-11e6-9f3f-ae90702daa4b.png">
