### PR TITLE
Update fix for footer in theme

### DIFF
--- a/assets/stylesheets/coursemology.org/layout.scss
+++ b/assets/stylesheets/coursemology.org/layout.scss
@@ -7,15 +7,47 @@
   box-shadow: 0 $v-shadow $blur $spread $gray-light;
 }
 
+html {
+  min-height: 100%;
+  position: relative;
+}
+
+.footer-buffer {
+
+  @media screen and (max-width: 937px) {
+    padding-bottom: 120px;
+  }
+
+  @media screen and (max-width: 553px) {
+    padding-bottom: 150px;
+  }
+
+  @media screen and (min-width: 937px) {
+    padding-bottom: 70px;
+  }
+}
+
 footer {
   border-top: 1px solid $gray-lighter;
+  bottom: 0;
   color: $gray-light;
+  height: 50px;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 100%;
 
   p {
     padding-top: ($grid-gutter-width / 2);
   }
 
+  .footer-copyright {
+    min-width: 405px;
+    padding: 10px 15px;
+  }
+
   .nav-pills {
+
     .footer-link {
       a {
         color: $gray-light;
@@ -25,6 +57,26 @@ footer {
         background: transparent;
         color: $cyan;
       }
+    }
+  }
+
+  @media screen and (max-width: 937px) {
+    height: 100px;
+  }
+
+  @media screen and (max-width: 553px) {
+    height: 130px;
+  }
+
+  @media screen and (min-width: 937px) {
+    height: 50px;
+
+    .footer-links {
+      float: right;
+    }
+
+    .nav-pills {
+      float: right;
     }
   }
 }

--- a/views/layouts/coursemology.org.html.slim
+++ b/views/layouts/coursemology.org.html.slim
@@ -87,7 +87,7 @@ html
               li
                 = link_to(t('layout.navbar.sign_in'), new_user_session_path)
 
-    div.container-fluid
+    div.container-fluid.footer-buffer
       = global_announcements
       = flash_messages
       div class=page_class
@@ -96,8 +96,8 @@ html
     footer
       div.container-fluid
         div.row
-          div.col-lg-12
-            nav.pull-right
+          div.col-md-7.col-lg-7.footer-links
+            nav
               ul.nav.nav-pills
                 li.footer-link
                   = link_to('Terms of Service', page_path('terms_of_service'))
@@ -109,4 +109,5 @@ html
                   = link_to('Contact Us', page_path('contact_us'))
                 li.footer-link
                   a href='https://github.com/Coursemology' target='_blank' GitHub
-            p © 2013 - #{Time.zone.now.year} Coursemology.org. All Rights Reserved.
+          div.col-md-5.col-lg-5
+            p.footer-copyright © 2013 - #{Time.zone.now.year} Coursemology.org. All Rights Reserved.


### PR DESCRIPTION
![screenshot 2017-02-11 01 04 19](https://cloud.githubusercontent.com/assets/7563985/22836093/0ece9faa-eff6-11e6-93f7-46e9ded84f5b.png)

Previous solution added bottom padding to `body` class instead of `container-fluid`, causing footer to overlap with the page.

Fixes #18.