### PR TITLE
Revert add popup notifer node

### DIFF
--- a/views/layouts/coursemology.org.html.slim
+++ b/views/layouts/coursemology.org.html.slim
@@ -88,8 +88,6 @@ html
               li
                 = link_to(t('layout.navbar.sign_in'), new_user_session_path)
 
-    #popup-notifier data=controller.next_popup_notification
-
     div.container-fluid.footer-buffer
       = global_announcements
       = flash_messages


### PR DESCRIPTION
The node was added to the course layout, not this outer layout. The addition of the node was therefore necessary.