### PR TITLE
Remove sidebar hamburger button from topbar

### DIFF
--- a/views/layouts/_topbar.html.slim
+++ b/views/layouts/_topbar.html.slim
@@ -7,13 +7,6 @@ nav.navbar.navbar-inverse.navbar-fixed-top role="navigation"
         span.icon-bar
         span.icon-bar
         span.icon-bar
-      - if sidebar?
-        button.navbar-toggle type="button" data-toggle="collapse" data-target=".sidebar" aria-expanded="false" aria-controls="navbar"
-          span.sr-only
-            = t('layout.navbar.toggle_sidebar')
-          span.icon-bar
-          span.icon-bar
-          span.icon-bar
       a.navbar-brand href=root_path
         = t('layout.coursemology')
       / .fb-like-button is our custom class that we use for CSS styling;


### PR DESCRIPTION
Fix https://github.com/Coursemology/coursemology2/issues/3065

This PR removes sidebar hamburger button from topbar.
https://github.com/Coursemology/coursemology2/pull/3097/files adds sidebar hamburger button to user row